### PR TITLE
add ﾌﾞﾙﾙｯﾁﾓ counting capability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -650,6 +650,7 @@ const oppapi = new Map([
     [/こじじ+ら/, 'こじら'],
     [/mattt+n/, 'mattn'],
     [/おっっ+ぱい/, 'おっぱい'],
+    [/ﾌﾞﾙﾙﾙ+ｯﾁﾓ/, 'ﾌﾞﾙﾙｯﾁﾓ'],
 ]);
 
 async function doOppapi(request: Request, env: Env): Promise<Response> {


### PR DESCRIPTION
It would be nice if nullpoga had capability of counting ﾙ in `/ﾌﾞﾙﾙﾙ+ｯﾁﾓ/` like [this post](https://njump.me/nevent1qqswnqcjhkvxtdwsghaw65a2udw3e3p26g2uzz4a07p7d9j8uf5rzjgpz3mhxue69uhhyetvv9ujuerpd46hxtnfdupzqn5xeka3a468laqvv5cr687yv0ss4m93zvzfkp0ugvtu9833ej40tcq3pp)